### PR TITLE
Better Compliance with PKGBUILD Standards

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,22 +1,27 @@
 pkgbase = windscribe-cli
 	pkgdesc = Port of Windscribe's command line interface
-	pkgver = 1.3
-	pkgrel = 19
+	pkgver = 1.3_19
+	pkgrel = 1
 	url = https://windscribe.com/
 	install = windscribe-cli.install
 	arch = x86_64
 	arch = i686
 	arch = armv6h
-	license = GPL-2+
+	license = GPL
 	depends = openvpn
 	optdepends = stunnel
-	replaces = windscribe-cli
-	source_x86_64 = windscribe-cli_1.3_19.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_1.3-19_amd64.deb
+	source_x86_64 = windscribe-cli_1.3_19_1.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_1.3-19_amd64.deb
+	source_x86_64 = windscribe.service
 	sha256sums_x86_64 = 2adef3ff36423de681279a7f8ddaac29612779bdbcba9cf24098952646fa0253
-	source_i686 = windscribe-cli_1.3_19.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_1.3-19_i386.deb
+	sha256sums_x86_64 = 5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06
+	source_i686 = windscribe-cli_1.3_19_1.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_1.3-19_i386.deb
+	source_i686 = windscribe.service
 	sha256sums_i686 = 141d9d229cd94de6d5212f909840682f5bf2d85f0de91407cf7fec28ff79161f
-	source_armv6h = windscribe-cli_1.3_19.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_1.3-19_armhf.deb
+	sha256sums_i686 = 5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06
+	source_armv6h = windscribe-cli_1.3_19_1.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_1.3-19_armhf.deb
+	source_armv6h = windscribe.service
 	sha256sums_armv6h = af8938c03355c7523f3abbe2090cbc43b7f782c3f1caf90c19b91b03173dd524
+	sha256sums_armv6h = 5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06
 
 pkgname = windscribe-cli
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,32 @@
 version: 2.0
 jobs:
   build:
+    working_directory: /windscribe-build
     docker:
-      - image: base/devel:latest
+      - image: archlinux/base:latest
     steps:
+      - checkout
       - run: 
           name: Update Pacman
           command: 'pacman -Syu --noconfirm'
       - run: 
-          name: Install Git
-          command: 'pacman -S git --noconfirm'
+          name: Install Dependencies
+          command: 'pacman -S git sudo base-devel --noconfirm'
       - run: 
           name: Create windscribe User and Add to Wheel Group
           command: 'useradd -m -g wheel -s /bin/bash windscribe'
+      - run:
+          name: Change Build Directory Ownership
+          command: 'chown -R windscribe /windscribe-build'
       - run: 
           name: Give Wheel Group sudoers Permission
           command: "sed -i '85s/.*/%wheel ALL=(ALL) NOPASSWD: ALL/' /etc/sudoers"
-      - run:
-          name: Checkout Code from GitHub
-          command: 'su - windscribe -c "git clone https://github.com/hkuchampudi/Windscribe.git"'
       - run: 
           name: Build PKGBUILD as windscribe User
-          command: 'su - windscribe -c "cd ~/Windscribe && makepkg -cs PKGBUILD --noconfirm"'
+          command: 'su - windscribe -c "cd /windscribe-build && makepkg -cs PKGBUILD --noconfirm"'
       - run: 
           name: Install Built Windscribe Package
-          command: 'su - windscribe -c "cd ~/Windscribe && sudo pacman -U *.pkg.tar.xz --noconfirm"'
+          command: 'su - windscribe -c "cd /windscribe-build && sudo pacman -U *.pkg.tar.xz --noconfirm"'
       ## Start tests
       - run: 
           name: Start Windscribe Service

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,18 +14,20 @@ license=('GPL')
 depends=('openvpn')
 optdepends=('stunnel')
 install="windscribe-cli.install"
-source_armv6h=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_armhf.deb"
-               'windscribe.service')
-source_i686=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_i386.deb"
-             'windscribe.service')
-source_x86_64=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_amd64.deb"
-               'windscribe.service')
-sha256sums_armv6h=('af8938c03355c7523f3abbe2090cbc43b7f782c3f1caf90c19b91b03173dd524'
-                   '5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06')
-sha256sums_i686=('141d9d229cd94de6d5212f909840682f5bf2d85f0de91407cf7fec28ff79161f'
-                 '5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06')
-sha256sums_x86_64=('2adef3ff36423de681279a7f8ddaac29612779bdbcba9cf24098952646fa0253'
-                   '5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06')
+
+# Platform specific binaries
+source_armv6h=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_armhf.deb")
+source_i686=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_i386.deb")
+source_x86_64=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_amd64.deb")
+
+# Common files
+source=('windscribe.service')
+
+# Checksums
+sha256sums_armv6h=('af8938c03355c7523f3abbe2090cbc43b7f782c3f1caf90c19b91b03173dd524')
+sha256sums_i686=('141d9d229cd94de6d5212f909840682f5bf2d85f0de91407cf7fec28ff79161f')
+sha256sums_x86_64=('2adef3ff36423de681279a7f8ddaac29612779bdbcba9cf24098952646fa0253')
+sha256sums=('5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06')
 
 package() {
   # Extract the debian package
@@ -46,7 +48,7 @@ package() {
 
   # Configure systemd service
   echo "Configuring systemd service"
-  install -Dm664 "windscribe.service" -t "${pkgdir}/usr/lib/systemd/system/"
+  install -Dm644 "windscribe.service" -t "${pkgdir}/usr/lib/systemd/system/"
   
   # Configure windscribe binary and license
   echo "Configuring binary and license"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,26 +1,31 @@
 ##########################################################################
 # Maintainer:   Harsha Kuchampudi <harshakuchampudi AT gmail DOT com>
 # Github:       https://github.com/hkuchampudi/Windscribe
-# Updated:      2018-10-03
+# Updated:      2019-03-09
 ##########################################################################
 
 pkgname=windscribe-cli
-pkgver=1.3
-pkgrel=19
+pkgver=1.3_19
+pkgrel=1
 pkgdesc="Port of Windscribe's command line interface"
 arch=('x86_64' 'i686' 'armv6h')
 url="https://windscribe.com/"
-license=('GPL-2+')
+license=('GPL')
 depends=('openvpn')
 optdepends=('stunnel')
-replaces=('windscribe-cli')
 install="windscribe-cli.install"
-source_armv6h=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver}-${pkgrel}_armhf.deb")
-source_i686=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver}-${pkgrel}_i386.deb")
-source_x86_64=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver}-${pkgrel}_amd64.deb")
-sha256sums_armv6h=('af8938c03355c7523f3abbe2090cbc43b7f782c3f1caf90c19b91b03173dd524')
-sha256sums_i686=('141d9d229cd94de6d5212f909840682f5bf2d85f0de91407cf7fec28ff79161f')
-sha256sums_x86_64=('2adef3ff36423de681279a7f8ddaac29612779bdbcba9cf24098952646fa0253')
+source_armv6h=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_armhf.deb"
+               'windscribe.service')
+source_i686=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_i386.deb"
+             'windscribe.service')
+source_x86_64=("${pkgname}_${pkgver}_${pkgrel}.deb::https://assets.staticnetcontent.com/desktop/linux/windscribe-cli_${pkgver//_/-}_amd64.deb"
+               'windscribe.service')
+sha256sums_armv6h=('af8938c03355c7523f3abbe2090cbc43b7f782c3f1caf90c19b91b03173dd524'
+                   '5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06')
+sha256sums_i686=('141d9d229cd94de6d5212f909840682f5bf2d85f0de91407cf7fec28ff79161f'
+                 '5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06')
+sha256sums_x86_64=('2adef3ff36423de681279a7f8ddaac29612779bdbcba9cf24098952646fa0253'
+                   '5be3a28e3b49a233b68ac4638bc5407e1fde043de5bfaddff00d0031947a6d06')
 
 package() {
   # Extract the debian package
@@ -31,43 +36,20 @@ package() {
   tar xf "data.tar.xz" -C "${srcdir}/data"
   tar xf "control.tar.gz" -C "${srcdir}/control"
   
-  # Create systemd service
-  echo "Creating systemd service"
-  mkdir -p $srcdir/data/etc/systemd/system
-  echo "
-  [Unit]
-  Description=Windscribe VPN CLI Service
-  After=syslog.target network.target remote-fs.target nss-lookup.target
-
-  [Service]
-  Type=simple
-  ExecStart=/usr/bin/windscribe start
-  ExecStop=/usr/bin/windscribe stop
-  Restart=on-failure
-  KillMode=control-group
-  SuccessExitStatus=SIGKILL
-  PIDFile=/etc/windscribe/windscribe.pid
-
-  [Install]
-  WantedBy=multi-user.target
-  " >> $srcdir/data/etc/systemd/system/windscribe.service
-  
   # Configure bash completion
   echo "Configuring bash completion"
-  mkdir $pkgdir/etc
-  cp -r "${srcdir}/data/etc/bash_completion.d" "${pkgdir}/etc/"
+  install -Dm644 "${srcdir}/data/etc/bash_completion.d/windscribe_complete" -t "${pkgdir}/etc/bash_completion.d/"
+
   # Make windscribe directory
   echo "Creating windscribe directory"
   mkdir $pkgdir/etc/windscribe
+
   # Configure systemd service
   echo "Configuring systemd service"
-  mkdir -p $pkgdir/etc/systemd/system/
-  cp "${srcdir}/data/etc/systemd/system/windscribe.service" "${pkgdir}/etc/systemd/system/"
-  chmod 0664 "${pkgdir}/etc/systemd/system/windscribe.service"
-  # Configure windscribe binary and docs
-  echo "Configuring binary and docs"
-  mkdir -p $pkgdir/usr/bin
-  cp -r "${srcdir}/data/usr/" "${pkgdir}/"
-  chmod 0755 "${pkgdir}/usr/bin/windscribe"
-  chmod 0755 -R "${pkgdir}/usr/share/doc/windscribe-cli" 
+  install -Dm664 "windscribe.service" -t "${pkgdir}/usr/lib/systemd/system/"
+  
+  # Configure windscribe binary and license
+  echo "Configuring binary and license"
+  install -Dm755 "${srcdir}/data/usr/bin/windscribe" -t "${pkgdir}/usr/bin/"
+  install -Dm644 "${srcdir}/data/usr/share/doc/windscribe-cli/copyright" "${pkgdir}/usr/share/licenses/windscribe-cli/LICENSE"
 }

--- a/windscribe-cli.install
+++ b/windscribe-cli.install
@@ -16,6 +16,7 @@ pre_remove() {
 post_remove() {
   rm -rf /etc/windscribe
   rm -rf /usr/share/doc/windscribe-cli
+  rm -rf /usr/share/licenses/windscribe-cli
   rm -rf /etc/bash_completion.d/windscribe_complete
   rm -rf /var/log/windscribe
   systemctl daemon-reload

--- a/windscribe.service
+++ b/windscribe.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Windscribe VPN CLI Service
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/windscribe start
+ExecStop=/usr/bin/windscribe stop
+Restart=on-failure
+KillMode=control-group
+SuccessExitStatus=SIGKILL
+PIDFile=/etc/windscribe/windscribe.pid
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Changelog
This update focuses on better compliance to official PKGBUILD standards (and should have no impact on how users use the program). Listed below are some of the changes made:

- **replaces:** The package no longer replaces itself as there are no packages under the same name. (this is addressed in fixes #6)
- **systemd:** The systemd service has been moved out of the PKGBUILD and is instead included in the `windscribe.service` file. Additionally, on the system, the service has been moved from `/etc/systemd/system` to `/usr/lib/systemd/system` which is where packages should install the service.
- **license:** The official license provided with the binary has been moved to `/usr/share/licenses/windscribe-cli/` folder which is where license files should be stored on Arch systems.
- **CircleCI:** Updated CircleCI build directions to use the new, official Arch Linux Docker image.
