### PR TITLE
Added -p to mkdir to allow for rebuilding in same dir

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -33,8 +33,8 @@ package() {
   # Extract the debian package
   echo "Extracting debian package"
   ar vx $srcdir/${pkgname}_${pkgver}_${pkgrel}.deb
-  mkdir $srcdir/data
-  mkdir $srcdir/control
+  mkdir -p $srcdir/data
+  mkdir -p $srcdir/control
   tar xf "data.tar.xz" -C "${srcdir}/data"
   tar xf "control.tar.gz" -C "${srcdir}/control"
 


### PR DESCRIPTION
Previously a build in an already used directory caused an error.
Adding -p to mkdir allows the build to be redone in an already used directory.